### PR TITLE
AWS documentation updates

### DIFF
--- a/IPIonAWSGovManualIAM.md
+++ b/IPIonAWSGovManualIAM.md
@@ -20,20 +20,51 @@ A video that walks through this guide is available here: https://youtu.be/bHmcWH
 
 In this guide, we will install OpenShift onto an existing AWS GovCloud VPC. This VPC will contain three private subnets that have no connectivity to the internet, as well as a public subnet that will facilitate our access to the private subnets from the internet (bastion). We still need to allow access to the AWS APIs from the private subnets. For this demo, that AWS API communication is facilitated by a squid proxy. Without that access, we will not be able to install a cloud aware OpenShift cluster. 
 
-A Cloud Formation template that details the VPC with squid proxy used in this demo can be found [**here**](https://github.com/dmc5179/openshift4-disconnected/blob/master/cloudformation/disconnected_vpc/disconnected_vpc.yaml). This demo assumes these are provided, but this template may be leveraged to create these resources if desired.
-
-
 This guide will assume that the user has valid accounts and subscriptions to both Red Hat OpenShift and AWS GovCloud.
+
+A Cloud Formation template that details the VPC with squid proxy used in this demo can be found [**here**](https://raw.githubusercontent.com/redhat-cop/ocp-disconnected-docs/main/aws-gov-ipi-dis-maniam/cloudformation.yaml). 
+
+Before running the cloud formation, ensure the following is created.
+
+1. A key-pair. This command will pull your local public key.
+```sh
+aws ec2 import-key-pair --key-name disconnected-east-1 --public-key-material fileb://~/.ssh/id_rsa.pub
+```
+
+2. The VPC Network & Subnets. Copy the cloud formation file to your local directory before running.
+```sh
+aws cloudformation create-stack --stack-name ocpdd --template-body file://./cloudformation.yaml --capabilities CAPABILITY_IAM
+```
+
+3. Bastion on Public Subnet on VPC created
+- Allow 22 (default)
+- Ensure at least 50G of disk space is allocated
+
+Register the machine and ensure the following packages are installed
+- podman
+- unzip
+- aws-cli (see https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html#cliv2-linux-install)
+
+4. Private registry on Private Subnet on VPC created
+- Allow 22 (default)
+- Allow 5000
+- Ensure at least 50G of disk space is allocated
+_You may wish to generate another key on the public bastion and add it's public key here before creation. Use the same method as step 1 on the bastion with a unique name._
+
+Ensure the following binaries are transferred and installed
+- https://github.com/itchyny/gojq (mv release and rename to /usr/bin/jq)
+- aws-cli (transfer the install directory and run the install)
+
 #
 ## Installing OpenShift 
 
 ### Create OpenShift Installation Bundle
-1. Download and compress the stable release bundle on internet an connected machine using the OpenShift4-mirror companion utility found [**here**](https://repo1.dso.mil/platform-one/distros/red-hat/ocp4/openshift4-mirror)
+1. Download and compress the stable release bundle on internet an connected machine using the OpenShift4-mirror companion utility found **[here](https://github.com/redhat-cop/ocp-disconnected-docs.git)**
    
 
    You will first need to retrieve an OpenShift pull secret. Once you have retrieved that, enter it into the literals of the value for `--pull-secret` in the command below. Pull secrets can be obtained from https://cloud.redhat.com/openshift/install/aws/installer-provisioned
 
-    ```
+    ```bash
     OCP_VER=$(curl http://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/release.txt 2>&1 | grep -oP "(?<=Version:\s\s).*")
     podman run -it --security-opt label=disable -v ./:/app/bundle quay.io/redhatgov/openshift4_mirror:latest \
       ./openshift_mirror bundle \
@@ -41,8 +72,8 @@ This guide will assume that the user has valid accounts and subscriptions to bot
       --platform aws \
       --skip-existing \
       --skip-catalogs \
-      --pull-secret '{"auths":{"cloud.openshift.com":{"auth":"b3Blb...' && \
-    git clone https://repo1.dso.mil/platform-one/distros/red-hat/ocp4/documentation.git ./${OCP_VER}/ocp-disconnected && \
+      --pull-secret ${PULL_SECRET} && \
+    git clone https://github.com/redhat-cop/ocp-disconnected-docs.git ./${OCP_VER}/ocp-disconnected && \
     tar -zcvf openshift-${OCP_VER}.tar.gz ${OCP_VER}
     ```
 2. Transfer bundle from internet connected machine to disconnected vpc host.
@@ -50,15 +81,14 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 #
 ### Prepare and Deploy
 3. Extract bundle on disconnected vpc host. From the directory containing the OCP bundle.
-    ```
+    ```bash
     OCP_VER=$(ls | grep -oP '(?<=openshift-)\d\.\d\.\d(?=.tar.gz)')    
     tar -xzvf openshift-${OCP_VER}.tar.gz
     ```
 
 4. Create S3 Bucket and attach policies.
 
-    ```
-    
+    ```bash
     export awsreg=$(aws configure get region)
     export s3name=$(date +%s"-rhcos")
     aws s3api create-bucket --bucket ${s3name} --region ${awsreg} --create-bucket-configuration LocationConstraint=${awsreg}
@@ -69,7 +99,7 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 
 5. Upload RHCOS Image to S3
 
-    ```
+    ```bash
     export RHCOS_VER=$(ls ./${OCP_VER}/rhcos/ | grep -oP '.*(?=\.vmdk.gz)')
     gzip -d ./${OCP_VER}/rhcos/${RHCOS_VER}.vmdk.gz
     aws s3 mv ./${OCP_VER}/rhcos/${RHCOS_VER}.vmdk s3://${s3name}
@@ -77,7 +107,7 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 
 6. Create AMI
 
-    ```
+    ```bash
     envsubst < ./${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam/containers-templ.json > ./${OCP_VER}/ocp-disconnected/containers.json
     taskid=$(aws ec2 import-snapshot --region ${awsreg} --description "rhcos-snapshot" --disk-container file://${OCP_VER}/ocp-disconnected/containers.json | jq -r '.ImportTaskId')
     until [[ $resp == "completed" ]]; do sleep 2; echo "Snapshot progress: "$(aws ec2 describe-import-snapshot-tasks --region ${awsreg} | jq --arg task "$taskid" -r '.ImportSnapshotTasks[] | select(.ImportTaskId==$task) | .SnapshotTaskDetail.Progress')"%"; resp=$(aws ec2 describe-import-snapshot-tasks --region ${awsreg} | jq --arg task "$taskid" -r '.ImportSnapshotTasks[] | select(.ImportTaskId==$task) | .SnapshotTaskDetail.Status'); done
@@ -96,20 +126,20 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 7. Record the AMI ID from the output of the above command.
 
 8. Create registry cert on disconnected vpc host
-    ```
+    ```bash
     export SUBJ="/C=US/ST=Virginia/O=Red Hat/CN=${HOSTNAME}"
-    openssl req -newkey rsa:4096 -nodes -sha256 -keyout registry.key -x509 -days 365 -out registry.crt -subj "$SUBJ"
+    openssl req -newkey rsa:4096 -nodes -sha256 -keyout registry.key -x509 -days 365 -out registry.crt -subj "$SUBJ" -addext "subjectAltName = DNS:$HOSTNAME"
     ```    
 
 9. Make a copy of the install config
-    ```
+    ```bash
     mkdir ./${OCP_VER}/config
     cp ./${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam/install-config-template.yaml ./${OCP_VER}/config/install-config.yaml
     ```
 10. Edit install config
     For this step, Open `./${OCP_VER}/config/install-config.yaml` and edit the following fields:
 
-    ```
+    ```yaml
     baseDomain: i.e. example.com
     additionalTrustBundle: copy and paste the content of ./registry.crt here.
     imageContentSources:
@@ -131,42 +161,38 @@ This guide will assume that the user has valid accounts and subscriptions to bot
     Don't forget to save and close the file!
 
 11. Make a backup of the final config:
-    ```
+    ```bash
     cp -R ./${OCP_VER}/config/ ./${OCP_VER}/config.bak
     ```
 
 12. Create manifests from install config.
-    ```
+    ```bash
     openshift-install create manifests --dir ./${OCP_VER}/config
     ```
 
-13. Delete the installer generated secret
-    ```
-    rm ./${OCP_VER}/config/openshift/99_cloud-creds-secret.yaml 
-    ```
-14. create iam users and Policies
+13. create iam users and Policies
 
-    ```
+    ```bash
     cd ./${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam
     chmod +x ./ocp-users.sh
     ./ocp-users.sh prepPolicies
     ./ocp-users.sh createUsers
     ```
 
-15. Use the convenience script to create the aws credentials and kubernetes secrets:
-    ```
+14. Use the convenience script to create the aws credentials and kubernetes secrets:
+    ```bash
     chmod +x ./secret-helper.sh
     ./secret-helper.sh
     cp secrets/* ../../config/openshift/
     cd -
     ```
 
-16. start up the registry in the background
-    ```
+15. start up the registry in the background
+    ```bash
     oc image serve --dir=./${OCP_VER}/release/ --tls-crt=./registry.crt --tls-key=./registry.key &
     ```
 
-17. Deploy the cluster
+16. Deploy the cluster
 
     ```
     openshift-install create cluster --dir ./${OCP_VER}/config
@@ -176,7 +202,7 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 
 You can now access the cluster via CLI with oc or the web console with a web browser.
 
-18. Locate the OpenShift access information provided by the final installer output.
+1. Locate the OpenShift access information provided by the final installer output.
 
     Example:
     ```
@@ -188,13 +214,16 @@ You can now access the cluster via CLI with oc or the web console with a web bro
     INFO Time elapsed: 48m34s    
     ```
 
-19. Set the default kube context used by oc and kubectl:  
+2. Set the default kube context used by oc and kubectl:  
 
     Example:
     ```
     export KUBECONFIG=/home/ec2-user/data/vid-pres/4.7.0/config/auth/kubeconfig
     ```
-20. Access the web console:
+
+    _Config file optionaly availible at `$OCP_VER/config/auth`_
+
+3. Access the web console:
 
     URL Example:
     `https://console-openshift-console.apps.test-cluster.testocp1.net`

--- a/aws-gov-ipi-dis-maniam/cloudformation.yaml
+++ b/aws-gov-ipi-dis-maniam/cloudformation.yaml
@@ -1,0 +1,481 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for Best Practice VPC with 1-3 AZs
+
+# 192.168.0.0/16
+
+Parameters:
+
+  VpcCidr:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
+    Default: 10.0.0.0/16
+    Description: CIDR block for VPC.
+    Type: String
+
+  AvailabilityZoneCount:
+    ConstraintDescription: "The number of availability zones. (Min: 1, Max: 3)"
+    MinValue: 1
+    MaxValue: 3
+    Default: 3
+    Description: "How many AZs to create VPC subnets for. (Min: 1, Max: 3)"
+    Type: Number
+
+  SubnetBits:
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/19-27.
+    MinValue: 5
+    MaxValue: 13
+    Default: 12
+    Description: "Size of each subnet to create within the availability zones. (Min: 5 = /27, Max: 13 = /19)"
+    Type: Number
+
+  AmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+    Description: AMI ID pointer in AWS Systems Manager Parameter Store. Default value points to the
+      latest Amazon Linux 2 AMI ID.
+
+  #KeyName:
+  #  Type: AWS::EC2::KeyPair::KeyName
+  #  Description: Name of RSA key for EC2 access for testing and troubleshooting.
+
+  InstanceType:
+    Type: String
+    Default: t3.small
+    Description: Instance type to use to launch the NAT instances.
+    AllowedValues:
+    - t3.nano
+    - t3.micro
+    - t3.small
+    - t3.medium
+    - t3.large
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - m5.large
+    - m5.xlarge
+    - m5.2xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.large
+    - c5.large
+    - c5.xlarge
+    - c5.large
+
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcCidr
+      - SubnetBits
+    - Label:
+        default: "Availability Zones"
+      Parameters:
+      - AvailabilityZoneCount
+    ParameterLabels:
+      AvailabilityZoneCount:
+        default: "Availability Zone Count"
+      VpcCidr:
+        default: "VPC CIDR"
+      SubnetBits:
+        default: "Bits Per Subnet"
+
+Conditions:
+  DoAz3: !Equals [3, !Ref AvailabilityZoneCount]
+  DoAz2: !Or [!Equals [2, !Ref AvailabilityZoneCount], Condition: DoAz3]
+
+Resources:
+
+  VPC:
+    Type: "AWS::EC2::VPC"
+    Properties:
+      EnableDnsSupport: "true"
+      EnableDnsHostnames: "true"
+      CidrBlock: !Ref VpcCidr
+
+#####################################################################
+# Public Subnets
+
+  PublicSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      MapPublicIpOnLaunch: true
+      Tags:
+      - Key: Name
+        Value: !Sub 'Public Subnet - ${AWS::StackName}'
+      AvailabilityZone: !Select
+      - 0
+      - Fn::GetAZs: !Ref "AWS::Region"
+
+  PublicSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz2
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      MapPublicIpOnLaunch: true
+      Tags:
+      - Key: Name
+        Value: !Sub 'Public Subnet 2 - ${AWS::StackName}'
+      AvailabilityZone: !Select
+      - 1
+      - Fn::GetAZs: !Ref "AWS::Region"
+
+  PublicSubnet3:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz3
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      MapPublicIpOnLaunch: true
+      Tags:
+      - Key: Name
+        Value: !Sub 'Public Subnet 3 - ${AWS::StackName}'
+      AvailabilityZone: !Select
+      - 2
+      - Fn::GetAZs: !Ref "AWS::Region"
+
+  InternetGateway:
+    Type: "AWS::EC2::InternetGateway"
+
+  GatewayToInternet:
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref VPC
+
+  PublicRoute:
+    Type: "AWS::EC2::Route"
+    DependsOn: GatewayToInternet
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnetRouteTableAssociation2:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Condition: DoAz2
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnetRouteTableAssociation3:
+    Condition: DoAz3
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet3
+      RouteTableId: !Ref PublicRouteTable
+
+####################################################################3
+# Private Subnets
+
+  PrivateSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      Tags:
+      - Key: Name
+        Value: !Sub 'Private Subnet - ${AWS::StackName}'
+      AvailabilityZone: !Select
+      - 0
+      - Fn::GetAZs: !Ref "AWS::Region"
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: !Sub 'Private Route Table - ${AWS::StackName}'
+
+  PrivateRouteTableSubnetAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnetNATRoute:
+    Type: AWS::EC2::Route
+    DependsOn: NATInstance
+    Properties:
+       RouteTableId:
+         Ref: PrivateRouteTable
+       DestinationCidrBlock: 0.0.0.0/0
+       InstanceId: !Ref NATInstance
+
+  PrivateSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz2
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      Tags:
+      - Key: Name
+        Value: !Sub 'Private Subnet 2 - ${AWS::StackName}'
+      AvailabilityZone: !Select
+      - 1
+      - Fn::GetAZs: !Ref "AWS::Region"
+
+  PrivateRouteTable2:
+    Type: AWS::EC2::RouteTable
+    Condition: DoAz2
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: !Sub 'Private Route Table 2 - ${AWS::StackName}'
+
+  PrivateRouteTableSubnetAssociation2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: DoAz2
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      RouteTableId: !Ref PrivateRouteTable2
+
+  PrivateSubnetNATRoute2:
+    Type: AWS::EC2::Route
+    Condition: DoAz2
+    DependsOn: NATInstance
+    Properties:
+       RouteTableId:
+         Ref: PrivateRouteTable2
+       DestinationCidrBlock: 0.0.0.0/0
+       InstanceId: !Ref NATInstance
+
+  PrivateSubnet3:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz3
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      Tags:
+      - Key: Name
+        Value: !Sub 'Private Subnet 3 - ${AWS::StackName}'
+      AvailabilityZone: !Select
+      - 2
+      - Fn::GetAZs: !Ref "AWS::Region"
+
+  PrivateRouteTable3:
+    Type: AWS::EC2::RouteTable
+    Condition: DoAz3
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: !Sub 'Private Route Table 3 - ${AWS::StackName}'
+
+  PrivateRouteTableSubnetAssociation3:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: DoAz3
+    Properties:
+      SubnetId: !Ref PrivateSubnet3
+      RouteTableId: !Ref PrivateRouteTable3
+
+  PrivateSubnetNATRoute3:
+    Type: AWS::EC2::Route
+    Condition: DoAz3
+    DependsOn: NATInstance
+    Properties:
+       RouteTableId:
+         Ref: PrivateRouteTable3
+       DestinationCidrBlock: 0.0.0.0/0
+       InstanceId: !Ref NATInstance
+
+##############################################################################
+#
+# NAT Instance
+########
+
+  NATInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+      - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+#          - Effect: Allow
+#            Action:
+#            - s3:GetObject
+#            - s3:ListObject
+#            Resource: !Sub '${S3Bucket.Arn}*'
+          - Effect: Allow
+            Action:
+            - ec2:ModifyInstanceAttribute
+            Resource: '*'
+
+  NATInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+      - !Ref NATInstanceRole
+      Path: /
+
+  NATInstanceSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allows HTTP and HTTPS from private instances to NAT instances
+      SecurityGroupIngress:
+      - CidrIp: !Ref VpcCidr
+        FromPort: 80
+        ToPort: 80
+        IpProtocol: TCP
+      - CidrIp: !Ref VpcCidr
+        FromPort: 443
+        ToPort: 443
+        IpProtocol: TCP
+      - CidrIp: '10.0.0.0/25'
+        FromPort: 80
+        ToPort: 80
+        IpProtocol: TCP
+      - CidrIp: '10.0.0.0/25'
+        FromPort: 443
+        ToPort: 443
+        IpProtocol: TCP
+      Tags:
+      - Key: Name
+        Value: !Sub 'NAT Instance SG - ${AWS::StackName}'
+      VpcId: !Ref VPC
+
+  NATInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AmiId
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref NATInstanceProfile
+      KeyName: disconnected-east-1
+      NetworkInterfaces:
+      - AssociatePublicIpAddress: "true"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref NATInstanceSG
+        SubnetId: !Ref PublicSubnet
+      UserData:
+        Fn::Base64:
+          !Sub |
+            #!/bin/bash -xe
+            # Redirect the user-data output to the console logs
+            exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+            # Apply the latest security patches
+            yum update -y --security
+
+            # Disable source / destination check. It cannot be disabled from the launch configuration
+            region=${AWS::Region}
+            instanceid=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+            aws ec2 modify-instance-attribute --no-source-dest-check --instance-id $instanceid --region $region
+
+            # Install and start Squid
+            yum install -y squid
+            systemctl enable --now squid
+            sleep 5
+            iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 3129
+            iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 3130
+
+            cp -a /etc/squid /etc/squid_orig
+
+            # Create a SSL certificate for the SslBump Squid module
+            mkdir /etc/squid/ssl
+            pushd /etc/squid/ssl
+            openssl genrsa -out squid.key 4096
+            openssl req -new -key squid.key -out squid.csr -subj "/C=US/ST=VA/L=squid/O=squid/CN=squid"
+            openssl x509 -req -days 3650 -in squid.csr -signkey squid.key -out squid.crt
+            cat squid.key squid.crt >> squid.pem
+
+            echo '.amazonaws.com' > /etc/squid/whitelist.txt
+            echo '.cloudfront.net' >> /etc/squid/whitelist.txt
+
+            cat > /etc/squid/squid.conf << 'EOF'
+
+            visible_hostname squid
+            cache deny all
+
+            # Log format and rotation
+            logformat squid %ts.%03tu %6tr %>a %Ss/%03>Hs %<st %rm %ru %ssl::>sni %Sh/%<a %mt
+            logfile_rotate 10
+            debug_options rotate=10
+
+            # Handle HTTP requests
+            http_port 3128
+            http_port 3129 intercept
+
+            # Handle HTTPS requests
+            https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept
+            acl SSL_port port 443
+            http_access allow SSL_port
+            acl step1 at_step SslBump1
+            acl step2 at_step SslBump2
+            acl step3 at_step SslBump3
+            ssl_bump peek step1 all
+
+            # Deny requests to proxy instance metadata
+            acl instance_metadata dst 169.254.169.254
+            http_access deny instance_metadata
+
+            # Filter HTTP requests based on the whitelist
+            acl allowed_http_sites dstdomain "/etc/squid/whitelist.txt"
+            http_access allow allowed_http_sites
+
+            # Filter HTTPS requests based on the whitelist
+            acl allowed_https_sites ssl::server_name "/etc/squid/whitelist.txt"
+            ssl_bump peek step2 allowed_https_sites
+            ssl_bump splice step3 allowed_https_sites
+            ssl_bump terminate step2 all
+
+            http_access deny all
+
+
+            EOF
+
+            /usr/sbin/squid -k parse && /usr/sbin/squid -k reconfigure
+
+# End Nat Instance
+############################################################################
+
+Outputs:
+  VpcId:
+    Description: ID of the new VPC.
+    Value: !Ref VPC
+  PublicSubnetIds:
+    Description: Subnet IDs of the public subnets.
+    Value:
+      !Join [
+        ",",
+        [!Ref PublicSubnet, !If [DoAz2, !Ref PublicSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PublicSubnet3, !Ref "AWS::NoValue"]]
+      ]
+  PrivateSubnetIds:
+    Description: Subnet IDs of the private subnets.
+    Value:
+      !Join [
+        ",",
+        [!Ref PrivateSubnet, !If [DoAz2, !Ref PrivateSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PrivateSubnet3, !Ref "AWS::NoValue"]]
+      ]


### PR DESCRIPTION
1. Declares requirements for bastions and registry
2. Adds SAN `-addext "subjectAltName = DNS:$HOSTNAME"` to registry cer for troubleshooting against podman and future proofing. Podman currently yields the following error when trying to access a registry image
```
Error: Error initializing source docker://ip-10-0-75-65.us-gov-east-1.compute.internal:5000/openshift/release@sha256:afcb309425d45a240de2df8e376f9632e6144052177fd62a0347934657b3573f: error pinging docker registry ip-10-0-75-65.us-gov-east-1.compute.internal:5000: Get "https://ip-10-0-75-65.us-gov-east-1.compute.internal:5000/v2/": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with 
```

3. Adopts CloudFormation manifest into repo
4. Formatting

Side note,
The registry also complains about access errors during installation `I0706 23:51:49.307559   10555 log.go:181] http: TLS handshake error from x.x.x.x:xxxxx: remote error: tls: bad certificate` regardless of whether the SAN is added or not. This may be a separate report. 